### PR TITLE
Make parser more robust

### DIFF
--- a/slm.toml
+++ b/slm.toml
@@ -1,5 +1,5 @@
 name = "toml"
-version = "0.4.3"
+version = "0.4.4"
 
 [dependencies]
 maybe-utils = { git = "StanzaOrg/maybe-utils", version = "0.1.6" }

--- a/src/toml/parser.stanza
+++ b/src/toml/parser.stanza
@@ -14,7 +14,7 @@ public defstruct TomlParserError <: Exception :
   msg:String|Printable
 
 defmethod print (o:OutputStream, e:TomlParserError):
-  print(o, "[%_:%~:%~]: error: %~" % [file-name(e), line(e), column(e), to-string(msg(e))])
+  print(o, "[%_:%~:%~]:\n%_" % [file-name(e), line(e), column(e), msg(e)])
 
 defstruct ParsePosition:
   offset: Int
@@ -61,6 +61,10 @@ defn skip-whitespace (parser: Parser) -> False:
   take-while(parser, is-whitespace)
   false
 
+defn skip-spaces (parser: Parser) -> False:
+  take-while(parser, {_ == ' '})
+  false
+
 defn eat-comment (parser: Parser) -> False:
   take-while(parser, fn (c): c != '\n' and c != '\r')
   expect-newline(parser)
@@ -70,14 +74,16 @@ defn expect (parser: Parser, value: Char) -> False|Void:
   if peek(parser) == One(value):
     advance(parser)
   else:
-    error(parser, "Expected: `%~`\nGot: `%~`" % [value, peek(parser)])
+    error(parser, "Expected: %~, found: %~" % [value, peek(parser)])
 
 defn expect-newline (parser: Parser) -> False|Void:
+  skip-spaces(parser)
   if peek(parser) == One('\r'):
     advance(parser)
   expect(parser, '\n')
 
 defn expect-newline-or-eof (parser:Parser) -> False|Void:
+  skip-spaces(parser)
   if peek(parser) == One('\r'):
     advance(parser)
   match(peek(parser)):
@@ -85,7 +91,7 @@ defn expect-newline-or-eof (parser:Parser) -> False|Void:
       if value(c) == '\n':
         advance(parser)
       else:
-        error(parser, "Expected: `%~`\nGot: `%~`" % [value, peek(parser)])
+        error(parser, "Expected: %~, found: %~" % [value, peek(parser)])
     (x:None):
       false
 
@@ -117,7 +123,7 @@ defn parse-table (parser: Parser) -> KeyValue<String, TomlTable>:
   expect(parser, '[')
   val key = parse-key(parser)
   expect(parser, ']')
-  expect-newline(parser)
+  expect-newline-or-eof(parser)
 
   val table = TomlTable()
   parse-table-inner(parser, table, false)
@@ -128,7 +134,7 @@ defn parse-identifier (parser: Parser) -> String:
   debug("trace: parse-identifier")
   val key = take-while(parser, is-identifier)
   if length(key) == 0:
-    error(parser, "Expected identifier, got: `%~`" % [peek(parser)])
+    error(parser, "Expected identifier, found: %~" % [peek(parser)])
   key
 
 defn parse-key (parser: Parser) -> String:
@@ -214,7 +220,7 @@ defn parse-table-inner (parser: Parser, table: TomlTable, root?: True|False) -> 
             insert(table, parse-key-value(parser))
             expect-newline-or-eof(parser)
           else:
-            error(parser, "Unexpected character: '%_'" % [c])
+            error(parser, "Unexpected character: %_" % [c])
         (_):
           error(parser, "Unexpected EOF")
 

--- a/src/toml/tests/basic.stanza
+++ b/src/toml/tests/basic.stanza
@@ -165,3 +165,53 @@ deftest inline-table-key-num:
   val toml = table $ parse-string $ "foo3 = { bar = { baz = 10, bang = \"hello\" } }\n"
   #EXPECT(toml["foo3.bar.baz"] as Int == 10)
   #EXPECT(toml["foo3.bar.bang"] as String == "hello")
+
+deftest whitespace-line-end:
+  val toml = table $ parse-string $ dedent $ \<>
+    foo = "bar"  
+    bar = 1    
+    [dependencies]    
+    stanza-toml = "git@github.com:tylanphear/stanza-toml"
+    poet = "git@github.com:tylanphear/poet"
+  <>
+
+  #EXPECT(get-str?(toml, "non-existent") is None)
+  #EXPECT(get-int?(toml, "non-existent") is None)
+  #EXPECT(get-table?(toml, "non-existent") is None)
+
+  val uut-str = get-str?(toml, "foo")
+  #EXPECT(uut-str is One)
+  #EXPECT(value!(uut-str) == "bar")
+
+  val uut-int = get-int?(toml, "bar")
+  #EXPECT(uut-int is One)
+  #EXPECT(value!(uut-int) == 1)
+
+  val uut-table = get-table?(toml, "dependencies")
+  #EXPECT(uut-table is One)
+  val cnt = length $ entries $ value!(uut-table)
+  #EXPECT(cnt == 2)
+
+
+deftest no-newline-table:
+  val toml = table $ parse-string $ dedent $ \<>
+    foo = "bar"  
+    bar = 1    
+    [dependencies]<>
+
+  #EXPECT(get-str?(toml, "non-existent") is None)
+  #EXPECT(get-int?(toml, "non-existent") is None)
+  #EXPECT(get-table?(toml, "non-existent") is None)
+
+  val uut-str = get-str?(toml, "foo")
+  #EXPECT(uut-str is One)
+  #EXPECT(value!(uut-str) == "bar")
+
+  val uut-int = get-int?(toml, "bar")
+  #EXPECT(uut-int is One)
+  #EXPECT(value!(uut-int) == 1)
+
+  val uut-table = get-table?(toml, "dependencies")
+  #EXPECT(uut-table is One)
+  val cnt = length $ entries $ value!(uut-table)
+  #EXPECT(cnt == 0)


### PR DESCRIPTION
* Allow whitespace before newlines
* Allow eof after parsing table key
* slightly prettier errors
  * dropped a bunch of quotes since `%~` for chars already includes them